### PR TITLE
Require fileutils as it's not loaded by default in Ruby.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [3.1, 3.2]
     services:
       postgres:
         image: postgres:14
@@ -31,7 +34,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Run tests
         run: bin/test

--- a/lib/veksel/cli.rb
+++ b/lib/veksel/cli.rb
@@ -13,6 +13,7 @@ module Veksel
       require 'veksel/commands/fork'
       require 'psych'
       require 'ostruct'
+      require 'fileutils'
 
       config = Psych.safe_load(File.read('config/database.yml'), aliases: true)['development'].transform_keys(&:to_sym)
       target_database = config[:database] + Veksel.suffix


### PR DESCRIPTION
I was getting 

```
/Users/nashby/code/veksel/lib/veksel/cli.rb:23:in `fork': uninitialized constant Veksel::CLI::FileUtils (NameError)

      FileUtils.touch('tmp/restart.txt')
      ^^^^^^^^^
Did you mean?  FileTest
```

when I tried to fork a DB in a newly created Rails project.