### PR TITLE
chore: Let db adapter to decide how to handle database target and source names.

### DIFF
--- a/lib/veksel/cli.rb
+++ b/lib/veksel/cli.rb
@@ -15,11 +15,8 @@ module Veksel
       require 'ostruct'
       require 'fileutils'
 
-      config = read_config('config/database.yml')[:development]
-
-      target_database = config[:database] + Veksel.suffix
-      db = OpenStruct.new(configuration_hash: config, database: target_database)
-      Veksel::Commands::Fork.new(db).perform
+      database_config = read_config('config/database.yml')[:development]
+      Veksel::Commands::Fork.new(database_config).perform
 
       duration = ((Time.now.to_f - t1) * 1000).to_i
       FileUtils.touch('tmp/restart.txt')

--- a/lib/veksel/commands/fork.rb
+++ b/lib/veksel/commands/fork.rb
@@ -5,10 +5,11 @@ module Veksel
     class Fork
       attr_reader :pg_cluster, :source_db, :target_db
 
-      def initialize(db)
-        @pg_cluster = PgCluster.new(db.configuration_hash)
-        @source_db = db.database.sub(%r[#{Veksel.suffix}$], '')
-        @target_db = db.database
+      def initialize(database_config)
+        @pg_cluster = PgCluster.new(database_config)
+        @source_db = pg_cluster.source_database_name
+        @target_db = pg_cluster.target_database_name
+
         raise "Source and target databases cannot be the same" if source_db == target_db
       end
 

--- a/lib/veksel/pg_cluster.rb
+++ b/lib/veksel/pg_cluster.rb
@@ -1,9 +1,9 @@
 module Veksel
   class PgCluster
-    attr_reader :configuration_hash
+    attr_reader :database_config
 
-    def initialize(configuration_hash)
-      @configuration_hash = configuration_hash
+    def initialize(database_config)
+      @database_config = database_config
     end
 
     def target_populated?(dbname)
@@ -40,6 +40,14 @@ module Veksel
       spawn(pg_env, %[dropdb --no-password #{dbname}])
     end
 
+    def source_database_name
+      database_config[:database]
+    end
+
+    def target_database_name
+      database_config[:database] + Veksel.suffix
+    end
+
     private
 
     def pg_connection_args(dbname)
@@ -48,10 +56,10 @@ module Veksel
 
     def pg_env
       {
-        'PGHOST' => configuration_hash[:host],
-        'PGPORT' => configuration_hash[:port]&.to_s,
-        'PGUSER' => configuration_hash[:username],
-        'PGPASSWORD' => configuration_hash[:password],
+        'PGHOST' => database_config[:host],
+        'PGPORT' => database_config[:port]&.to_s,
+        'PGUSER' => database_config[:username],
+        'PGPASSWORD' => database_config[:password],
       }.compact
     end
   end


### PR DESCRIPTION
When I started looking into adding `sqlite` support I noticed that for `sqlite` in `database.yml` you have db like `db/development.sqlite3` so just adding a suffix won't work, it should have a bit different logic. So I've extracted these db name method to db adapter class and future sqlite adapter can have specific logic for it.