### PR TITLE
Loose Rails version dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     veksel (0.3.0)
       activerecord
-      rails (>= 7.1.0, < 8)
+      rails (>= 7.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/veksel.gemspec
+++ b/veksel.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.executables << 'veksel'
 
-  spec.add_dependency "rails", ">= 7.1.0", "< 8"
+  spec.add_dependency "rails", ">= 7.1.0"
   spec.add_dependency "activerecord"
 end


### PR DESCRIPTION
Since Rails 8.0 is released now. Personally I think it doesn't make much sense to limit Rails max version here at all.